### PR TITLE
Fixed conflicting IDs for tags

### DIFF
--- a/src/lib/values/index.js
+++ b/src/lib/values/index.js
@@ -4,8 +4,9 @@
 export const convertPayloadToValues = ({ meta, payload = [] }) => {
   return meta
     .filter(({ Type }) => Type === 'SoftwareTag' || Type === 'DeviceTag')
-    .map(({ Attribute, Id }) => {
-      const obj = payload.find(val => val.Id === Id) || {}
-      return { Attribute, Values: obj.Values?.map(({ Value }) => Value) }
-    })
+    .map(({ Type, Attribute, Id }) => {
+      const obj =
+        payload.find((val) => val.Id === Id && val.TypeName === Type) || {};
+      return { Attribute, Values: obj.Values?.map(({ Value }) => Value) };
+    });
 }


### PR DESCRIPTION
There are different APIs for different types and have same IDs sometimes. Resulting in values showing up from a different type. We need to check to the Type also.